### PR TITLE
Throw a `TypeError` if trying to parse something not a string.

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -45,6 +45,10 @@ function parseProperties(scheme, string) {
 
 
 function parseAuthorization(str) {
+	if (!_.isString(str)) {
+		throw new TypeError('Header value must be a string.');
+	}
+
 	var start = str.indexOf(' '),
 		scheme = str.substr(0, start);
 

--- a/test/spec/parse.spec.js
+++ b/test/spec/parse.spec.js
@@ -10,6 +10,24 @@ describe('parse', function() {
 		}).to.throw(TypeError);
 	});
 
+	it('should fail if a boolean', function() {
+		expect(function() {
+			parse(true);
+		}).to.throw(TypeError);
+	});
+
+	it('should fail if an object', function() {
+		expect(function() {
+			parse({ });
+		}).to.throw(TypeError);
+	});
+
+	it('should fail if null', function() {
+		expect(function() {
+			parse(null);
+		}).to.throw(TypeError);
+	});
+
 	it('should coalesce many values', function() {
 		var result = parse('foo a=1 a=2 a=3');
 		expect(result).to.deep.equal({


### PR DESCRIPTION
It makes no sense to parse something that isn't a string, so include checks for it, lest the user sees some obscure error about `indexOf`.
