### PR TITLE
Add real "Header" object that handles multi-value management.

### DIFF
--- a/lib/format.js
+++ b/lib/format.js
@@ -65,20 +65,23 @@ function buildChallenge(params, options) {
 	}
 }
 
-function buildHeader(obj) {
-	if (_.isString(obj)) {
-		obj = { scheme: obj };
+function buildHeader(scheme, token, params) {
+	var obj;
+
+	if (_.isString(scheme)) {
+		obj = { scheme: scheme, token: token, params: params };
+	} else {
+		obj = scheme;
 	}
 
 	if (!_.isObject(obj)) {
 		throw new TypeError();
-	}
-	else if (!util.isScheme(obj.scheme)) {
+	} else if (!util.isScheme(obj.scheme)) {
 		throw new TypeError('Invalid scheme.');
 	}
 
-	var params = buildChallenge(obj.params),
-		token = buildChallenge(obj.token);
+	params = buildChallenge(obj.params);
+	token = buildChallenge(obj.token);
 
 	return obj.scheme
 		+ (token ? ' ' + token : '')

--- a/lib/header.js
+++ b/lib/header.js
@@ -3,7 +3,69 @@
 
 'use strict';
 
-module.exports = {
-	parse: require('./parse'),
-	format: require('./format')
+var _ = require('lodash'),
+	parse = require('./parse'),
+	format = require('./format');
+
+function Header(options) {
+	if (this instanceof Header === false) {
+		return new Header(options);
+	} else if (_.isNull(options) || _.isUndefined(options)) {
+		this.values = [ ];
+	} else if (_.isArray(options)) {
+		this.values = _.map(options, Header.single);
+	} else {
+		this.values = [ Header.single(options) ];
+	}
+}
+
+Header.single = function single(value) {
+	if (_.isObject(value)) {
+		return value;
+	} else if (_.isString(value)) {
+		return parse(value);
+	} else {
+		throw new TypeError();
+	}
 };
+
+Header.parse = function _parse(str) {
+	return new Header(str);
+};
+
+Header.format = Header.challenge = function _format(scheme, params) {
+	return format(scheme, params);
+};
+
+Object.defineProperty(Header.prototype, 'length', {
+	get: function getLength() {
+		return this.values.length;
+	}
+});
+
+Header.createIsMatch = function createIsMatch(scheme, query) {
+	scheme = scheme.toLowerCase();
+	return function isMatch(value) {
+		return scheme === value.scheme.toLowerCase() &&
+			// TODO: Convert this to `_.isMatch(value.params, query)` when
+			// lodash ^3.0.0 hits npm.
+			(!query || _.find([value.params], query));
+	};
+};
+
+Header.prototype.is = function _is(type, query) {
+	return !!this.for(type, query);
+};
+
+Header.prototype.for = function _for(type, query) {
+	var result = _.filter(this.values, Header.createIsMatch(type, query));
+	if (result.length === 0) {
+		return null;
+	} else if (result.length > 1) {
+		throw new Error();
+	} else {
+		return result[0];
+	}
+};
+
+module.exports = Header;


### PR DESCRIPTION
This is particularly useful for handling more esoteric cases. For example, `express` provides `WWW-Authenticate` _either_ as a single string value, _or_ an array of values. Deciding what action to take, or even finding the relevant value you're interested in can be a pain; this wrapper class deals with that issue.

It is waiting on `lodash.isMatch` to do its pattern matching, which is unfortunately only available in `^3.0.0` which hasn't landed in npm yet. What can ya do?