### PR TITLE
Add check to ensure we're matching against a string for tokens.

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -1,10 +1,12 @@
 
 'use strict';
 
+var _ = require('lodash');
+
 var token = /^[^\u0000-\u001F\u007F()<>@,;:\\"/?={}\[\]\u0020\u0009]+$/;
 
 function isToken(str) {
-	return token.test(str);
+	return _.isString(str) && token.test(str);
 }
 
 module.exports = {


### PR DESCRIPTION
You'd figure `.test` would do this for you, but apparently there are some edge cases in which it fails.