### PR TITLE
add npmignore to fix require

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,3 @@
+node_modules
+coverage
+*.log


### PR DESCRIPTION
requiring this module did not work because the "dist/index.js" was the location to resolve but dist/ did not exist because it was .gitignored and ignored by npm as a result. Creating a similar .npmignore that does not ignore dist/ for npm installs allows dist/index.js to resolve and thus is able to be required.