### PR TITLE
parse multiple challenges when passing true to parse

### DIFF
--- a/src/parse.js
+++ b/src/parse.js
@@ -16,23 +16,35 @@ const normalize = (prev, _cur) => {
   return cur;
 };
 
-const parseProperties = (scheme, string) => {
+const parseProperties = (scheme, string, challenge) => {
   let res = null;
   let token = null;
-  const params = { };
+  let params = { };
+  const challenges = [];
+  let _scheme = scheme;
 
   while ((res = body.exec(string)) !== null) {
     if (res[2]) {
       params[res[1]] = normalize(params[res[1]], res[2]);
+    } else if (challenge) {
+      challenges.push({scheme: _scheme, params});
+      // Challenges don't have tokens so this is scheme for next challenge
+      _scheme = res[1].trim();
+      params = { };
     } else {
       token = normalize(token, res[1]);
     }
   }
 
+  if (challenge) {
+    challenges.push({scheme: _scheme, params});
+    return challenges;
+  }
+
   return {scheme, params, token};
 };
 
-export default (str) => {
+export default (str, challenge) => {
   if (typeof str !== 'string') {
     throw new TypeError('Header value must be a string.');
   }
@@ -44,5 +56,5 @@ export default (str) => {
     throw new TypeError(`Invalid scheme ${scheme}`);
   }
 
-  return parseProperties(scheme, str.substr(start));
+  return parseProperties(scheme, str.substr(start), challenge);
 };

--- a/test/spec/parse.spec.js
+++ b/test/spec/parse.spec.js
@@ -116,4 +116,22 @@ describe('parse', () => {
       },
     });
   });
+
+  it('should handle multiple challenges when asked', () => {
+    const result = parse('Bearer scope="openid", Basic realm="foo"', true);
+    expect(result).to.deep.equal([
+      {
+        scheme: 'Bearer',
+        params: {
+          scope: 'openid',
+        },
+      },
+      {
+        scheme: 'Basic',
+        params: {
+          realm: 'foo',
+        },
+      },
+    ]);
+  });
 });


### PR DESCRIPTION
This adds support for parsing multiple challenges in a single `WWW-Authenticate` header.

It assumes tokens don't appear in challenges. When the regex matches a token with no value, it assumes that token is really the scheme for the next challenge.

Since the new behavior of returning an array instead of a single object isn't triggered unless passing in `true`, I think it can be considered backwards compatible.