### PR TITLE
Slim down NPM package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,0 @@
-node_modules
-coverage
-*.log

--- a/package.json
+++ b/package.json
@@ -17,14 +17,15 @@
     "url": "https://github.com/izaakschroeder/auth-header.git"
   },
   "main": "dist/index.js",
+  "files": [
+    "dist",
+    "src"
+  ],
   "scripts": {
     "test": "npm run lint && npm run spec",
 		"prepublish": "./node_modules/.bin/babel -s -d dist src",
     "spec": "NODE_ENV=test ./node_modules/.bin/mocha --compilers js:babel-core/register -r adana-dump -R spec test/spec",
     "lint": "eslint --ignore-path .gitignore ."
-  },
-  "dependencies": {
-    "babel-core": "^6.4.5"
   },
   "devDependencies": {
     "adana-cli": "^0.1.1",


### PR DESCRIPTION
Fixes #18 

And removes `test` from the NPM package. See http://blog.npmjs.org/post/165769683050/publishing-what-you-mean-to-publish for reasoning.