### PR TITLE
Fix inorrect type

### DIFF
--- a/src/parse.js
+++ b/src/parse.js
@@ -22,7 +22,7 @@ const normalize = (
 
 type Result = {
   scheme: string,
-  params: {[string]: string},
+  params: {[string]: string | Array<string>},
   token: ?(string | Array<string>),
 };
 


### PR DESCRIPTION
`normalize` can return `string | string[]` so it is possible to have params be arrays, if they occur multiple times.