### PR TITLE
Fix parsing of `www-authenticate: Basic`

### DIFF
--- a/src/parse.js
+++ b/src/parse.js
@@ -51,7 +51,10 @@ export default (str: string): Result => {
     throw new TypeError('Header value must be a string.');
   }
 
-  const start = str.indexOf(' ');
+  let start = str.indexOf(' ');
+  if (start === -1) {
+    start = str.length;
+  }
   const scheme = str.substr(0, start);
 
   if (!isScheme(scheme)) {

--- a/test/spec/parse.spec.js
+++ b/test/spec/parse.spec.js
@@ -37,6 +37,15 @@ describe('parse', () => {
   });
 
   it('should handle Basic', () => {
+    const result = parse('Basic');
+    expect(result).toEqual({
+      scheme: 'Basic',
+      token: null,
+      params: {},
+    });
+  });
+
+  it('should handle Basic with credentials', () => {
     const result = parse('Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==');
     expect(result).toEqual({
       scheme: 'Basic',


### PR DESCRIPTION
When using `parse` against `www-authenticate: Basic`, current code fails with `Invalid Scheme`. This fixes this behavior.

According to `www-authenticate` specs, it should be able to parse values with only the scheme present: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/WWW-Authenticate